### PR TITLE
feat(storage): gérer les noms de fichiers nuls et sécuriser le stockage

### DIFF
--- a/src/main/java/com/jlh/jlhautopambackend/services/PromotionCleanupService.java
+++ b/src/main/java/com/jlh/jlhautopambackend/services/PromotionCleanupService.java
@@ -1,25 +1,77 @@
 package com.jlh.jlhautopambackend.services;
 
+import com.jlh.jlhautopambackend.modeles.Promotion;
 import com.jlh.jlhautopambackend.repositories.PromotionRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.*;
 import java.time.Instant;
+import java.util.List;
+
 @Service
 public class PromotionCleanupService {
 
-    private final PromotionRepository promoRepo;
+    private static final Logger log = LoggerFactory.getLogger(PromotionCleanupService.class);
 
-    public PromotionCleanupService(PromotionRepository promoRepo) {
+    private final PromotionRepository promoRepo;
+    private final Path uploadDir;
+
+    public PromotionCleanupService(PromotionRepository promoRepo,
+                                   @Value("${app.upload-dir}") String uploadDir) {
         this.promoRepo = promoRepo;
+        this.uploadDir = Paths.get(uploadDir);
     }
 
-    /** Supprime chaque jour à 23h59 toutes les promotions expirées. */
+    /**
+     * Supprime chaque jour à 23h59 toutes les promotions expirées
+     * et leurs images stockées sur le disque.
+     */
     @Scheduled(cron = "0 59 23 * * *")
     @Transactional
     public void removeExpiredPromotions() {
         Instant now = Instant.now();
-        promoRepo.deleteByValidToBefore(now);
+        // 1. Récupère d'abord les promotions expirées
+        List<Promotion> expired = promoRepo.findByValidToBefore(now);
+
+        for (Promotion promo : expired) {
+            String imageUrl = promo.getImageUrl();
+            String filename = extractFilename(imageUrl);
+            Path filePath = uploadDir.resolve(filename);
+            try {
+                if (Files.deleteIfExists(filePath)) {
+                    log.info("Image supprimée : {}", filePath);
+                } else {
+                    log.warn("Image non trouvée pour suppression : {}", filePath);
+                }
+            } catch (IOException e) {
+                log.error("Erreur lors de la suppression de l’image {} : {}", filePath, e.getMessage(), e);
+            }
+        }
+
+        // 2. Puis supprime définitivement les promotions en base
+        promoRepo.deleteAll(expired);
+        log.info("{} promotions expirées supprimées.", expired.size());
+    }
+
+    /**
+     * Extrait le nom de fichier à partir de l’URL (tout ce qui suit le dernier '/').
+     */
+    private String extractFilename(String imageUrl) {
+        try {
+            URI uri = URI.create(imageUrl);
+            String path = uri.getPath();
+            return Paths.get(path).getFileName().toString();
+        } catch (Exception e) {
+            log.error("Impossible d’extraire le nom de fichier de l’URL : {}", imageUrl, e);
+            // si échec, on renvoie l’intégralité de l’URL en nom (improbable mais sûr)
+            return imageUrl;
+        }
     }
 }

--- a/src/main/java/com/jlh/jlhautopambackend/services/PromotionServiceImpl.java
+++ b/src/main/java/com/jlh/jlhautopambackend/services/PromotionServiceImpl.java
@@ -7,13 +7,18 @@ import com.jlh.jlhautopambackend.modeles.Administrateur;
 import com.jlh.jlhautopambackend.modeles.Promotion;
 import com.jlh.jlhautopambackend.repositories.AdministrateurRepository;
 import com.jlh.jlhautopambackend.repositories.PromotionRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.nio.file.*;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -23,6 +28,10 @@ public class PromotionServiceImpl implements PromotionService {
     private final PromotionRepository promoRepo;
     private final AdministrateurRepository adminRepo;
     private final PromotionMapper mapper;
+
+    /** Chemin absolu sur le disque où stocker les images */
+    @Value("${app.upload-dir}")
+    private String uploadDir;
 
     public PromotionServiceImpl(PromotionRepository promoRepo,
                                 AdministrateurRepository adminRepo,
@@ -48,62 +57,27 @@ public class PromotionServiceImpl implements PromotionService {
                 .map(mapper::toResponse);
     }
 
-    // --- surcharge pour vos tests sans MultipartFile ---
-
-    /**
-     * Crée une promotion (tests uniquement).
-     */
+    /** Création sans fichier, utilisée pour les tests */
     public PromotionResponse create(PromotionRequest req) {
-        // vérifie les dates
-        if (req.getValidFrom().isAfter(req.getValidTo())) {
-            throw new IllegalArgumentException("validFrom doit être avant validTo");
-        }
-
-        // charge l'admin
-        Administrateur admin = adminRepo.findById(req.getAdministrateurId())
-                .orElseThrow(() ->
-                        new IllegalArgumentException("Administrateur introuvable : " + req.getAdministrateurId())
-                );
-
-        // mappe en entité
+        validateDates(req.getValidFrom(), req.getValidTo());
+        Administrateur admin = loadAdmin(req.getAdministrateurId());
         Promotion entity = mapper.toEntity(req);
         entity.setAdministrateur(admin);
-
-        // persiste
         Promotion saved = promoRepo.save(entity);
         return mapper.toResponse(saved);
     }
 
-    /**
-     * Met à jour une promotion (tests uniquement).
-     */
+    /** Mise à jour sans fichier, utilisée pour les tests */
     public Optional<PromotionResponse> update(Integer id, PromotionRequest req) {
         Optional<Promotion> opt = promoRepo.findById(id);
-        if (opt.isEmpty()) {
-            return Optional.empty();
-        }
+        if (opt.isEmpty()) return Optional.empty();
+
+        validateDates(req.getValidFrom(), req.getValidTo());
         Promotion existing = opt.get();
-
-        // vérifie les dates
-        if (req.getValidFrom().isAfter(req.getValidTo())) {
-            throw new IllegalArgumentException("validFrom doit être avant validTo");
-        }
-
-        // si l'admin change, on le recharge
-        Integer newAdminId = req.getAdministrateurId();
-        if (!existing.getAdministrateur().getIdAdmin().equals(newAdminId)) {
-            Administrateur newAdmin = adminRepo.findById(newAdminId)
-                    .orElseThrow(() ->
-                            new IllegalArgumentException("Administrateur introuvable : " + newAdminId)
-                    );
-            existing.setAdministrateur(newAdmin);
-        }
-
-        // met à jour les autres champs
+        handleAdminChange(existing, req.getAdministrateurId());
         existing.setImageUrl(req.getImageUrl());
         existing.setValidFrom(req.getValidFrom());
         existing.setValidTo(req.getValidTo());
-
         Promotion saved = promoRepo.save(existing);
         return Optional.of(mapper.toResponse(saved));
     }
@@ -113,24 +87,81 @@ public class PromotionServiceImpl implements PromotionService {
         if (!promoRepo.existsById(id)) {
             return false;
         }
+        // On pourrait supprimer le fichier ici si on stocke le chemin dans la DB
         promoRepo.deleteById(id);
         return true;
     }
 
-    // --- implémentation de l’interface pour le controller (avec MultipartFile) ---
+    // --- implémentation avec MultipartFile ---
 
     @Override
     public PromotionResponse create(PromotionRequest req, MultipartFile file) throws IOException {
-        // si vous stockez le fichier, faites-le ici, par ex. :
-        // String url = fileStorageService.store(file);
-        // req.setImageUrl(url);
+        // si un fichier est fourni, on le stocke
+        if (file != null && !file.isEmpty()) {
+            String filename = storeFile(file);
+            req.setImageUrl("/promotions/images/" + filename);
+        }
         return create(req);
     }
 
     @Override
     public Optional<PromotionResponse> update(Integer id, PromotionRequest req, MultipartFile file) throws IOException {
-        // même remarque pour l’image :
-        // if (file != null) { … }
+        // on supprime l'ancienne image si on remplace
+        if (file != null && !file.isEmpty()) {
+            // charger l'ancienne entité pour récupérer l'URL
+            promoRepo.findById(id).ifPresent(old -> {
+                String oldUrl = old.getImageUrl();
+                if (oldUrl != null && oldUrl.startsWith("/promotions/images/")) {
+                    Path oldPath = Paths.get(uploadDir, oldUrl.substring("/promotions/images/".length()));
+                    try { Files.deleteIfExists(oldPath); } catch (IOException ignored) {}
+                }
+            });
+            String filename = storeFile(file);
+            req.setImageUrl("/promotions/images/" + filename);
+        }
         return update(id, req);
+    }
+
+    // --- méthodes utilitaires privées ---
+
+    private void validateDates(Instant from, Instant to) {
+        if (from.isAfter(to)) {
+            throw new IllegalArgumentException("validFrom doit être avant validTo");
+        }
+    }
+
+    private Administrateur loadAdmin(Integer adminId) {
+        return adminRepo.findById(adminId)
+                .orElseThrow(() ->
+                        new IllegalArgumentException("Administrateur introuvable : " + adminId)
+                );
+    }
+
+    private void handleAdminChange(Promotion existing, Integer newAdminId) {
+        if (!existing.getAdministrateur().getIdAdmin().equals(newAdminId)) {
+            Administrateur newAdmin = loadAdmin(newAdminId);
+            existing.setAdministrateur(newAdmin);
+        }
+    }
+
+    private String storeFile(MultipartFile file) throws IOException {
+        // Récupère le nom original, ou "" si null
+        String originalName = Optional.ofNullable(file.getOriginalFilename()).orElse("");
+
+        // Nettoie le chemin pour éviter les séquences malveillantes
+        String safeName = StringUtils.cleanPath(originalName);
+
+        // Construit un nom unique : UUID + (–nomNettoyé si présent)
+        String filename = UUID.randomUUID()
+                + (safeName.isEmpty() ? "" : "-" + safeName);
+
+        // Crée le dossier si besoin
+        Path targetDir = Paths.get(uploadDir).toAbsolutePath().normalize();
+        Files.createDirectories(targetDir);
+
+        // Transfère le fichier
+        Path target = targetDir.resolve(filename);
+        file.transferTo(target);
+        return filename;
     }
 }


### PR DESCRIPTION
- Utilisation de `Optional.ofNullable` pour remplacer un `null` de `getOriginalFilename()` par une chaîne vide
- Nettoyage du nom de fichier via `StringUtils.cleanPath()` afin d’éviter les séquences malveillantes
- Concaténation conditionnelle du suffixe “-nomFichier” uniquement si celui-ci n’est pas vide
- Génération d’un nom unique avec `UUID` pour garantir l’unicité des fichiers
- Création du dossier de destination si nécessaire avant transfert du fichier

Ces changements renforcent la robustesse du stockage de fichiers et évitent les erreurs liées à un nom original manquant ou malformé.