### PR TITLE
feat(ci): ajustement du workflow GitHub Actions pour build et push Do…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,30 @@
+# .github/workflows/ci-cd-backend.yml
 name: CI/CD Backend
 
-# On build & test sur dev et main
+# Permissions nécessaires pour push sur Docker Hub (packages) et checkout
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:
-      - dev
       - main
-  pull_request:
-    branches:
       - dev
 
 env:
   DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USERNAME }}
 
 jobs:
-  # 1️⃣ Build & test Java (toujours)
-  build:
+  build-and-push:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -31,26 +37,14 @@ jobs:
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-m2-${{ hashFiles('pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2-
+          restore-keys: |
+            ${{ runner.os }}-m2-
 
       - name: Run tests
         run: mvn test -B
 
       - name: Build JAR
         run: mvn clean package -DskipTests -B
-
-      # Expose le SHA pour éventuel tag dev
-      - name: Set image tag
-        if: ${{ github.ref == 'refs/heads/dev' }}
-        run: echo "IMAGE_TAG=dev-${GITHUB_SHA::8}" >> $GITHUB_ENV
-
-  # 2️⃣ Build & push Docker (seulement si on est sur main)
-  push-image:
-    needs: build
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2
@@ -59,6 +53,15 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Determine Docker image tag
+        id: set-tag
+        run: |
+          if [[ "${GITHUB_REF#refs/heads/}" == "main" ]]; then
+            echo "TAG=latest" >> $GITHUB_ENV
+          else
+            echo "TAG=dev-${GITHUB_SHA::8}" >> $GITHUB_ENV
+          fi
+
       - name: Build & push Docker image
         uses: docker/build-push-action@v4
         with:
@@ -66,18 +69,22 @@ jobs:
           file: Dockerfile
           push: true
           tags: |
-            ${{ env.DOCKERHUB_USER }}/jlh-autopam-backend:latest
+            ${{ env.DOCKERHUB_USER }}/jlh-autopam-backend:${{ env.TAG }}
 
       - name: Logout from Docker Hub
         run: docker logout docker.io
 
-  # 3️⃣ Déploiement prod (auto uniquement sur main)
   deploy-production:
-    needs: push-image
     if: github.ref == 'refs/heads/main'
+    needs: build-and-push
     runs-on: self-hosted
+    defaults:
+      run:
+        working-directory: .
+
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
 
       - name: Pull & run prod container
         run: |


### PR DESCRIPTION
…cker

- Ajout des permissions `contents: read` et `packages: write` pour autoriser le push des images sur Docker Hub
- Unification du job `build-and-push` pour gérer à la fois les tags `dev-<sha>` et `latest` selon la branche (`dev` ou `main`)
- Utilisation de `actions/checkout@v3`, `actions/setup-java@v3`, `actions/cache@v3` et `docker/build-push-action@v4`
- Détermination du tag Docker dans une étape dédiée (`Determine Docker image tag`)
- Séparation d’un job `deploy-production` conditionné uniquement sur la branche `main` pour pull et déployer le conteneur en production